### PR TITLE
v1.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ Refs. for badges:
 - http://github.com/wayneashleyberry/terminal-dimensions
 - https://github.com/golangci/golangci-lint
 
+## [1.5.8] - 2021-11-08
+### Changed
+- All `SetXYZ` methods returns its proper interface allowing method chaining.
+- `Breakpoint` is now variadic.
+- Properly handle cases where sypl writes to a piped output, but it's broken.
+
 ## [1.5.7] - 2021-11-02
 ### Changed
 - Fixed `ExampleNew_globalFields` test.

--- a/interface.go
+++ b/interface.go
@@ -209,7 +209,7 @@ type ISypl interface {
 	// the `debug` level. Arbitrary `data` can optionally be set - if set, it'll
 	// be printed. Errors are printed using the `error` level. Set logging level
 	// to `trace` for more.
-	Breakpoint(name string, data interface{}) ISypl
+	Breakpoint(name string, data ...interface{}) ISypl
 
 	// String interface.
 	String() string
@@ -225,7 +225,7 @@ type ISypl interface {
 	GetMaxLevel() map[string]level.Level
 
 	// SetMaxLevel sets the `maxLevel` of all outputs.
-	SetMaxLevel(l level.Level)
+	SetMaxLevel(l level.Level) ISypl
 
 	// AddOutputs adds one or more outputs.
 	AddOutputs(outputs ...output.IOutput) ISypl
@@ -234,7 +234,7 @@ type ISypl interface {
 	GetOutput(name string) output.IOutput
 
 	// SetOutputs sets one or more outputs. Use to update output(s).
-	SetOutputs(outputs ...output.IOutput)
+	SetOutputs(outputs ...output.IOutput) ISypl
 
 	// GetOutputs returns registered outputs.
 	GetOutputs() []output.IOutput

--- a/message/interface.go
+++ b/message/interface.go
@@ -36,13 +36,13 @@ type IMessage interface {
 	GetComponentName() string
 
 	// SetComponentName sets the component name.
-	SetComponentName(name string)
+	SetComponentName(name string) IMessage
 
 	// GetContent returns the content.
 	GetContent() content.IContent
 
 	// SetContent sets the content.
-	SetContent(c content.IContent)
+	SetContent(c content.IContent) IMessage
 
 	// GetDebugEnvVarRegexeses returns the Debug env var regexes matchers.
 	GetDebugEnvVarRegexes() *debug.Debug
@@ -54,13 +54,13 @@ type IMessage interface {
 	GetFields() fields.Fields
 
 	// SetFields sets the structured fields.
-	SetFields(fields fields.Fields)
+	SetFields(fields fields.Fields) IMessage
 
 	// GetFlag returns the flag.
 	GetFlag() flag.Flag
 
 	// SetFlag sets the flag.
-	SetFlag(flag flag.Flag)
+	SetFlag(flag flag.Flag) IMessage
 
 	// GetID returns the id.
 	GetID() string
@@ -72,13 +72,13 @@ type IMessage interface {
 	GetLevel() level.Level
 
 	// SetLevel sets the level.
-	SetLevel(l level.Level)
+	SetLevel(l level.Level) IMessage
 
 	// getLineBreaker returns linebreaker.
 	getLineBreaker() *lineBreaker
 
 	// setLineBreaker sets the linebreaker.
-	setLineBreaker(lB *lineBreaker)
+	setLineBreaker(lB *lineBreaker) IMessage
 
 	// GetMessage (low-level) returns the message.
 	GetMessage() *message
@@ -87,31 +87,31 @@ type IMessage interface {
 	GetOutputName() string
 
 	// SetOutputName sets the name of the output in use.
-	SetOutputName(outputName string)
+	SetOutputName(outputName string) IMessage
 
 	// GetOutputsNames returns the outputs names that should be used.
 	GetOutputsNames() []string
 
 	// SetOutputsNames sets the outputs names that should be used.
-	SetOutputsNames(outputsNames []string)
+	SetOutputsNames(outputsNames []string) IMessage
 
 	// GetProcessorName returns the name of the processor in use.
 	GetProcessorName() string
 
 	// SetProcessorName sets the name of the processor in use.
-	SetProcessorName(processorName string)
+	SetProcessorName(processorName string) IMessage
 
 	// GetProcessorsNames returns the processors names that should be used.
 	GetProcessorsNames() []string
 
 	// SetProcessorsNames sets the processors names that should be used.
-	SetProcessorsNames(processorsNames []string)
+	SetProcessorsNames(processorsNames []string) IMessage
 
 	// GetTimestamp returns the timestamp.
 	GetTimestamp() time.Time
 
 	// SetTimestamp sets the timestamp.
-	SetTimestamp(timestamp time.Time)
+	SetTimestamp(timestamp time.Time) IMessage
 }
 
 // ITag specifies what a Tag does.

--- a/message/message.go
+++ b/message/message.go
@@ -130,8 +130,10 @@ func (m *message) getLineBreaker() *lineBreaker {
 }
 
 // setLineBreaker sets the line break status.
-func (m *message) setLineBreaker(lB *lineBreaker) {
+func (m *message) setLineBreaker(lB *lineBreaker) IMessage {
 	m.lineBreaker = lB
+
+	return m
 }
 
 // Restore known linebreaks.
@@ -171,8 +173,10 @@ func (m *message) GetComponentName() string {
 }
 
 // SetComponentName sets the component name.
-func (m *message) SetComponentName(name string) {
+func (m *message) SetComponentName(name string) IMessage {
 	m.componentName = name
+
+	return m
 }
 
 // GetContent returns the content.
@@ -181,8 +185,10 @@ func (m *message) GetContent() content.IContent {
 }
 
 // SetContent sets the content.
-func (m *message) SetContent(c content.IContent) {
+func (m *message) SetContent(c content.IContent) IMessage {
 	m.Content = c
+
+	return m
 }
 
 // GetDebugEnvVarRegexeses returns the Debug env var regexes matchers.
@@ -203,8 +209,10 @@ func (m *message) GetFields() fields.Fields {
 }
 
 // SetFields sets the structured fields.
-func (m *message) SetFields(fields fields.Fields) {
+func (m *message) SetFields(fields fields.Fields) IMessage {
 	m.Fields = fields
+
+	return m
 }
 
 // GetFlag returns the flag.
@@ -213,8 +221,10 @@ func (m *message) GetFlag() flag.Flag {
 }
 
 // SetFlag sets the flag.
-func (m *message) SetFlag(flag flag.Flag) {
+func (m *message) SetFlag(flag flag.Flag) IMessage {
 	m.Flag = flag
+
+	return m
 }
 
 // GetID returns the id.
@@ -233,8 +243,10 @@ func (m *message) GetLevel() level.Level {
 }
 
 // SetLevel sets the level.
-func (m *message) SetLevel(l level.Level) {
+func (m *message) SetLevel(l level.Level) IMessage {
 	m.Level = l
+
+	return m
 }
 
 // GetMessage (low-level) returns the message.
@@ -248,8 +260,10 @@ func (m *message) GetOutputName() string {
 }
 
 // SetOutputName sets the name of the output in use.
-func (m *message) SetOutputName(outputName string) {
+func (m *message) SetOutputName(outputName string) IMessage {
 	m.OutputName = outputName
+
+	return m
 }
 
 // GetOutputsNames returns the outputs names that should be used.
@@ -258,8 +272,10 @@ func (m *message) GetOutputsNames() []string {
 }
 
 // SetOutputsNames sets the outputs names that should be used.
-func (m *message) SetOutputsNames(outputsNames []string) {
+func (m *message) SetOutputsNames(outputsNames []string) IMessage {
 	m.OutputsNames = outputsNames
+
+	return m
 }
 
 // GetProcessorName returns the name of the processor in use.
@@ -268,8 +284,10 @@ func (m *message) GetProcessorName() string {
 }
 
 // SetProcessorName sets the name of the processor in use.
-func (m *message) SetProcessorName(processorName string) {
+func (m *message) SetProcessorName(processorName string) IMessage {
 	m.ProcessorName = processorName
+
+	return m
 }
 
 // GetProcessorsNames returns the processors names that should be used.
@@ -278,8 +296,10 @@ func (m *message) GetProcessorsNames() []string {
 }
 
 // SetProcessorsNames sets the processors names that should be used.
-func (m *message) SetProcessorsNames(processorsNames []string) {
+func (m *message) SetProcessorsNames(processorsNames []string) IMessage {
 	m.ProcessorsNames = processorsNames
+
+	return m
 }
 
 // GetTimestamp returns the timestamp.
@@ -288,8 +308,10 @@ func (m *message) GetTimestamp() time.Time {
 }
 
 // SetTimestamp sets the timestamp.
-func (m *message) SetTimestamp(timestamp time.Time) {
+func (m *message) SetTimestamp(timestamp time.Time) IMessage {
 	m.Timestamp = timestamp
+
+	return m
 }
 
 //////

--- a/output/builtin.go
+++ b/output/builtin.go
@@ -47,7 +47,6 @@ func StdErr(processors ...processor.IProcessor) IOutput {
 }
 
 // FileBased is a built-in `output`, that writes to the specified file.
-// TODO: Remove `path`.
 func FileBased(
 	name string,
 	maxLevel level.Level,

--- a/output/interface.go
+++ b/output/interface.go
@@ -26,8 +26,7 @@ type IOutput interface {
 	GetBuiltinLogger() *builtin.Builtin
 
 	// SetBuiltinLogger sets the Golang's builtin logger.
-	// TODO: SetXYZ should return IOutput.
-	SetBuiltinLogger(builtinLogger *builtin.Builtin)
+	SetBuiltinLogger(builtinLogger *builtin.Builtin) IOutput
 
 	// GetFormatter returns the formatter.
 	GetFormatter() formatter.IFormatter
@@ -39,7 +38,7 @@ type IOutput interface {
 	GetMaxLevel() level.Level
 
 	// SetMaxLevel sets the max level.
-	SetMaxLevel(l level.Level)
+	SetMaxLevel(l level.Level) IOutput
 
 	// AddProcessors adds one or more processors.
 	AddProcessors(processors ...processor.IProcessor) IOutput
@@ -48,7 +47,7 @@ type IOutput interface {
 	GetProcessor(name string) processor.IProcessor
 
 	// SetProcessors sets one or more processors.
-	SetProcessors(processors ...processor.IProcessor)
+	SetProcessors(processors ...processor.IProcessor) IOutput
 
 	// GetProcessors returns registered processors.
 	GetProcessors() []processor.IProcessor
@@ -60,7 +59,7 @@ type IOutput interface {
 	GetWriter() io.Writer
 
 	// SetWriter sets the writer.
-	SetWriter(w io.Writer)
+	SetWriter(w io.Writer) IOutput
 
 	// Write write the message to the defined output.
 	Write(m message.IMessage) error

--- a/sypl.go
+++ b/sypl.go
@@ -417,14 +417,20 @@ func (sypl *Sypl) Traceln(args ...interface{}) ISypl {
 // the `debug` level. Arbitrary `data` can optionally be set - if set, it'll
 // be printed. Errors are printed using the `error` level. Set logging level
 // to `trace` for more.
-func (sypl *Sypl) Breakpoint(name string, data interface{}) ISypl {
+func (sypl *Sypl) Breakpoint(name string, data ...interface{}) ISypl {
 	breakpointName := fmt.Sprintf(`Breakpoint: %s. PID: %d`, name, os.Getpid())
 
 	if data != nil {
-		breakpointName = fmt.Sprintf("%s. Data: %+v", breakpointName, data)
+		breakpointName = fmt.Sprintf("%s. Data:", breakpointName)
+
+		for _, d := range data {
+			breakpointName = fmt.Sprintf("%s %+v,", breakpointName, d)
+		}
+
+		breakpointName = strings.TrimSuffix(breakpointName, ",")
 	}
 
-	sypl.Debuglnf("%s. Press enter to continue", breakpointName)
+	sypl.Debugf("%s. Press enter to continue...", breakpointName)
 
 	reader := bufio.NewReader(os.Stdin)
 
@@ -461,10 +467,12 @@ func (sypl *Sypl) GetMaxLevel() map[string]level.Level {
 }
 
 // SetMaxLevel sets the `maxLevel` of all outputs.
-func (sypl *Sypl) SetMaxLevel(l level.Level) {
+func (sypl *Sypl) SetMaxLevel(l level.Level) ISypl {
 	for _, output := range sypl.GetOutputs() {
 		output.SetMaxLevel(l)
 	}
+
+	return sypl
 }
 
 // AddOutputs adds one or more outputs.
@@ -487,7 +495,7 @@ func (sypl *Sypl) GetOutput(name string) output.IOutput {
 }
 
 // SetOutputs sets one or more outputs. Use to update output(s).
-func (sypl *Sypl) SetOutputs(outputs ...output.IOutput) {
+func (sypl *Sypl) SetOutputs(outputs ...output.IOutput) ISypl {
 	for _, output := range outputs {
 		for i, o := range sypl.outputs {
 			if strings.EqualFold(o.GetName(), output.GetName()) {
@@ -495,6 +503,8 @@ func (sypl *Sypl) SetOutputs(outputs ...output.IOutput) {
 			}
 		}
 	}
+
+	return sypl
 }
 
 // GetOutputs returns registered outputs.


### PR DESCRIPTION
- All `SetXYZ` methods returns its proper interface allowing method chaining.
- `Breakpoint` is now variadic.
- Properly handle cases where sypl writes to a piped output, but it's broken.